### PR TITLE
Reorder tracks

### DIFF
--- a/app/assets/javascripts/rmll/program.js
+++ b/app/assets/javascripts/rmll/program.js
@@ -15,6 +15,15 @@ function formatJson(json, callbackBuilding, callbackSetup) {
     if (days[i] != "friday" && days[i] != "thursday") data[days[i]] = [];
   }
 
+  // Reorder track list
+  var newOrderId = Array(10, 7, 1, 8, 15, 11, 19, 20, 9, 14, 18, 17, 13, 12, 25, 16, 24, 21, 2, 3, 4, 5, 6, 22, 23);
+  var newOrderTracks = Array();
+  for (var i = 0 ; i < newOrderId.length ; i++) {
+      newOrderTracks.push(json.tracks[newOrderId[i]-1]);
+  }
+  json.tracks = newOrderTracks;
+
+  // Apply trick to get translated name for tracks
   for (var i = 0; i < json.tracks.length; i++) {
     json.tracks[i].name = json.tracks[i].name.split("*")[lang];
     // console.log(json.tracks[i]);


### PR DESCRIPTION
This is a proposal to reorder tracks shown on the program ;)

The track order was initially completely random because we were still in the process of defining tracks.

Since the highlight of this edition is Education, imho it would make sense to have "Digital Education" and "Pedagogical tools" near the top.

The other things are a bit arbitrary, though the logic is to keep close ["Privacy" and "Decentralized Internet"], then ["Epistemo", "Cité numerique", "FuturC"], then ["Multimedia"(unused?), "Music and sound" and "Création"]

Feel free to provide feedback, reorder things and/or throw this in the trashbin :P 

Also the code is only partially tested because I don't have a dev environment :s 

![2018-07-03-171318_1366x768_scrot](https://user-images.githubusercontent.com/4533074/42228782-1c6e5f0e-7ee5-11e8-9992-bf6c873e2e7b.png)
